### PR TITLE
Final housekeeping: Go 1.25.11, root smoke test, and all pending dependency bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
 
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v5
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
 
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
         with:
           files: ./coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -20,4 +20,4 @@ jobs:
 
   scan-scheduled:
     if: github.event_name == 'push' || github.event_name == 'schedule'
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   scan-pr:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.5"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.8"
 
   scan-scheduled:
     if: github.event_name == 'push' || github.event_name == 'schedule'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           publish_results: true
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v3
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
 
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cmvp-tui
 
-![Go Version](https://img.shields.io/badge/go-1.25.7-blue)
+![Go Version](https://img.shields.io/badge/go-1.25.11-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![CI](https://github.com/ethanolivertroy/cmvp-tui/workflows/CI/badge.svg)
 ![Codecov](https://codecov.io/gh/ethanolivertroy/cmvp-tui/branch/main/graph/badge.svg)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethanolivertroy/cmvp-tui
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestDefaultVersion(t *testing.T) {
+	if version == "" {
+		t.Fatal("version must not be empty")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Consolidates all outstanding work so the repo can be released and archived:

- Add a minimal root package smoke test so coverage-enabled CI runs include the command package cleanly.
- Bump the Go toolchain from 1.25.7 to 1.25.11 (latest 1.25.x patch). Fixes the `govulncheck` Security workflow failure, which was reporting 9 stdlib vulnerabilities fixed in Go 1.25.8–1.25.10 (crypto/x509, crypto/tls, net/http, net/url, os). Update the README Go badge to match.
- Roll up all open dependabot PRs (this PR supersedes them; they can be closed after merge):
  - #38: osv-scanner-reusable.yml 2.3.5 → 2.3.8
  - #39: codecov/codecov-action 6.0.0 → 7.0.0
  - #40: osv-scanner-reusable-pr.yml 2.3.5 → 2.3.8
  - #41: actions/checkout 6.0.2 → 7.0.0
  - #42: github/codeql-action 4.35.1 → 4.36.2

## Verification
- `go test -race -coverprofile=coverage.out -covermode=atomic ./...` passes on Go 1.25.11
- `go build` and `cmvp -version` work
- govulncheck and all other CI checks were green on the pre-rollup revision
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0fad-f4f1-7712-afef-79bda94dff84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0fad-f4f1-7712-afef-79bda94dff84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a check to ensure the app reports a non-empty default version.
* **Chores**
  * Updated the Go toolchain version used by the project.
  * Refreshed the Go version badge in the README to match the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->